### PR TITLE
Add generate and generator to npm keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,5 @@
   "engines": {
     "node": "*"
   },
-  "keywords": [ "random", "mac address", "mac" ]
+  "keywords": [ "random", "mac address", "mac", "generate", "generator" ]
 }


### PR DESCRIPTION
I found this quite hard to find on npm as it wasn't coming up under "mac generator".